### PR TITLE
Added NS Usage Description in ProjectOxfordFace-Info.plist

### DIFF
--- a/Example/ProjectOxfordFace/ProjectOxfordFace-Info.plist
+++ b/Example/ProjectOxfordFace/ProjectOxfordFace-Info.plist
@@ -43,5 +43,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>For capturing photos</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Access photos from Album</string>
 </dict>
 </plist>


### PR DESCRIPTION
Added usage description for camera and photo library access. The app is crashing in iOS 10.