### PR TITLE
Add keys for access to user private data (Camera, PhotoLibrary)

### DIFF
--- a/Example/ProjectOxfordFace/en.lproj/InfoPlist.strings
+++ b/Example/ProjectOxfordFace/en.lproj/InfoPlist.strings
@@ -1,2 +1,3 @@
 /* Localized versions of Info.plist keys */
-
+"NSCameraUsageDescription" = "Requires access to the camera";
+"NSPhotoLibraryUsageDescription" = "Requires access to the photo library";


### PR DESCRIPTION
This example app will crash when user want to access camera or photo library if example app don't have the suggested key.