### PR TITLE
added missing eyebrowRightOuter landmark

### DIFF
--- a/Pod/Classes/MPOFaceLandmarks.h
+++ b/Pod/Classes/MPOFaceLandmarks.h
@@ -43,6 +43,7 @@
 @property MPOFaceFeatureCoordinate *eyeLeftTop;
 @property MPOFaceFeatureCoordinate *eyeLeftBottom;
 @property MPOFaceFeatureCoordinate *eyeLeftInner;
+@property MPOFaceFeatureCoordinate *eyebrowRightOuter;
 @property MPOFaceFeatureCoordinate *eyebrowRightInner;
 @property MPOFaceFeatureCoordinate *eyeRightInner;
 @property MPOFaceFeatureCoordinate *eyeRightTop;

--- a/Pod/Classes/MPOFaceLandmarks.h
+++ b/Pod/Classes/MPOFaceLandmarks.h
@@ -53,6 +53,7 @@
 @property MPOFaceFeatureCoordinate *noseRootRight;
 @property MPOFaceFeatureCoordinate *noseLeftAlarTop;
 @property MPOFaceFeatureCoordinate *noseLeftAlarOutTip;
+@property MPOFaceFeatureCoordinate *noseRightAlarTop;
 @property MPOFaceFeatureCoordinate *noseRightAlarOutTip;
 @property MPOFaceFeatureCoordinate *upperLipTop;
 @property MPOFaceFeatureCoordinate *upperLipBottom;

--- a/Pod/Classes/MPOFaceLandmarks.m
+++ b/Pod/Classes/MPOFaceLandmarks.m
@@ -46,6 +46,7 @@
         self.eyeLeftTop = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"eyeLeftTop"]];
         self.eyeLeftBottom = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"eyeLeftBottom"]];
         self.eyeLeftInner = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"eyeLeftInner"]];
+        self.eyebrowRightOuter = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"eyebrowRightOuter"]];
         self.eyebrowRightInner = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"eyebrowRightInner"]];
         self.eyeRightInner = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"eyeRightInner"]];
         self.eyeRightTop = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"eyeRightTop"]];

--- a/Pod/Classes/MPOFaceLandmarks.m
+++ b/Pod/Classes/MPOFaceLandmarks.m
@@ -56,6 +56,7 @@
         self.noseRootRight = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"noseRootRight"]];
         self.noseLeftAlarTop = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"noseLeftAlarTop"]];
         self.noseLeftAlarOutTip = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"noseLeftAlarOutTip"]];
+        self.noseRightAlarTop = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"noseRightAlarTop"]];
         self.noseRightAlarOutTip = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"noseRightAlarOutTip"]];
         self.upperLipTop = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"upperLipTop"]];
         self.upperLipBottom = [[MPOFaceFeatureCoordinate alloc] initWithDictionary:dict[@"upperLipBottom"]];


### PR DESCRIPTION
Looked like eyebrowRightOuter was missing in the list of face landmarks.  I’ve added the property and code to read it from the dict.