### PR TITLE
Update Project Oxford Face endpoint URL.

### DIFF
--- a/Example/ProjectOxfordFace/MPOAppDelegate.h
+++ b/Example/ProjectOxfordFace/MPOAppDelegate.h
@@ -33,7 +33,7 @@
 #import <CoreData/CoreData.h>
 
 static NSString *const ProjectOxfordFaceSubscriptionKey = @"Your Subscription Key";
-static NSString *const ProjectOxfordFaceEndpoint = @"https://westus.api.cognitive.microsoft.com/face/v1.0/";
+static NSString *const ProjectOxfordFaceEndpoint = @"https://westcentralus.api.cognitive.microsoft.com/face/v1.0/";
 
 @interface MPOAppDelegate : UIResponder <UIApplicationDelegate>
 


### PR DESCRIPTION
Looks like the previous URL is no longer working. When I tried to run the example project, the processing would fail. After updating to the URL provided through the Azure portal, everything works as expected.